### PR TITLE
Fix music loading and error screen issue

### DIFF
--- a/lib/modules/app/app_view.dart
+++ b/lib/modules/app/app_view.dart
@@ -74,48 +74,58 @@ class AppView extends GetView<AppController> {
             // Performance Dashboard (debug mode only)
             const PerformanceDashboard(),
 
-            // Loading overlay
-            if (controller.isLoading)
-              ColoredBox(
-                color: Colors.black54,
-                child: Center(
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      CircularProgressIndicator(
-                        color: Theme.of(context).colorScheme.primary,
-                        value: controller.loadingProgress,
-                      ),
-                      SizedBox(height: 2.h),
-                      Text(
-                        'Loading Music... ${(controller.loadingProgress * 100).toInt()}%',
-                        style: const TextStyle(
-                          color: Colors.white,
-                          fontSize: 16,
-                          fontWeight: FontWeight.bold,
+            // Loading overlay - only shown when loading AND no cached content
+            if (controller.shouldShowLoadingScreen)
+              AnimatedOpacity(
+                opacity: controller.shouldShowLoadingScreen ? 1.0 : 0.0,
+                duration: const Duration(milliseconds: 300),
+                child: ColoredBox(
+                  color: Colors.black87,
+                  child: Center(
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        CircularProgressIndicator(
+                          color: Theme.of(context).colorScheme.primary,
+                          value: controller.loadingProgress > 0
+                              ? controller.loadingProgress
+                              : null,
                         ),
-                      ),
-                      SizedBox(height: 1.h),
-                      Text(
-                        controller.loadingStatusMessage,
-                        style: const TextStyle(
-                          color: Colors.white70,
-                          fontSize: 14,
-                        ),
-                        textAlign: TextAlign.center,
-                      ),
-                      SizedBox(height: 2.h),
-                      SizedBox(
-                        width: 80.w,
-                        child: LinearProgressIndicator(
-                          value: controller.loadingProgress,
-                          backgroundColor: Colors.white24,
-                          valueColor: AlwaysStoppedAnimation<Color>(
-                            Theme.of(context).colorScheme.primary,
+                        SizedBox(height: 2.h),
+                        Text(
+                          controller.loadingProgress > 0
+                              ? 'Loading Music... ${(controller.loadingProgress * 100).toInt()}%'
+                              : 'Loading Music...',
+                          style: const TextStyle(
+                            color: Colors.white,
+                            fontSize: 16,
+                            fontWeight: FontWeight.bold,
                           ),
                         ),
-                      ),
-                    ],
+                        SizedBox(height: 1.h),
+                        Text(
+                          controller.loadingStatusMessage,
+                          style: const TextStyle(
+                            color: Colors.white70,
+                            fontSize: 14,
+                          ),
+                          textAlign: TextAlign.center,
+                        ),
+                        SizedBox(height: 2.h),
+                        SizedBox(
+                          width: 80.w,
+                          child: LinearProgressIndicator(
+                            value: controller.loadingProgress > 0
+                                ? controller.loadingProgress
+                                : null,
+                            backgroundColor: Colors.white24,
+                            valueColor: AlwaysStoppedAnimation<Color>(
+                              Theme.of(context).colorScheme.primary,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
                   ),
                 ),
               ),

--- a/lib/modules/home/albumsView.dart
+++ b/lib/modules/home/albumsView.dart
@@ -119,23 +119,24 @@ class _AlbumsViewState extends State<AlbumsView> {
             filteredAlbums.value = controller.albums;
           }
 
-          // Show error state if there's an error
-          if (controller.hasError) {
-            return _buildErrorView(context, controller);
+          // Priority 1: If we have albums, show them (even during errors/loading)
+          // This ensures cached content is always displayed
+          if (controller.albums.isNotEmpty) {
+            return _buildAlbumsGrid(context, controller);
           }
 
-          // Show loading state if initial loading
+          // Priority 2: Show loading state only if no albums and still loading
           if (controller.isLoading) {
             return _buildLoadingView(context, controller);
           }
 
-          // Show empty state if no albums
-          if (controller.albums.isEmpty) {
-            return _buildEmptyView(context);
+          // Priority 3: Show error state only if no albums and there's an error
+          if (controller.hasError) {
+            return _buildErrorView(context, controller);
           }
 
-          // Show albums grid
-          return _buildAlbumsGrid(context, controller);
+          // Priority 4: Show empty state if no albums and not loading/error
+          return _buildEmptyView(context);
         },
       );
 


### PR DESCRIPTION
This fixes the issue where the loading screen would finish before music was loaded, then show an error screen.

Key changes:
- Add MusicLoadingState enum for granular loading state control
- Implement cache-first loading: show cached content immediately, refresh from network in background
- Loading screen only shows when no cached content available
- Error screen only shows when both cache AND network fail
- Albums grid displays even during background refresh/errors if cached content exists
- Add shouldShowLoadingScreen getter for smarter UI control
- Add background refresh capability that doesn't block UI